### PR TITLE
Add Blockscout Explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Meet `--hoodi`, the second long-standing, merged-from-genesis, public Ethereum t
 * Homepage: [hoodi.ethpandaops.io](https://hoodi.ethpandaops.io)
 * Staking Launchpad: [hoodi.launchpad.ethereum.org](https://hoodi.launchpad.ethereum.org)
 * Block Explorers
+  * [hoodi.cloud.blockscout.com](https://hoodi.cloud.blockscout.com/)
   * [hoodi.etherscan.io](https://hoodi.etherscan.io/)
   * [hoodi.beaconcha.in](https://hoodi.beaconcha.in/)
   * [light-hoodi.beaconcha.in](https://light-hoodi.beaconcha.in/)


### PR DESCRIPTION
Added a Blockscout explorer, still currently syncing but is on our Autoscout account. Will commit to keeping it up for a good while, at least until there is an equal alternative and or Etherscan begins working.

Put up for our own purposes as well, so if not needed no worries.  

https://hoodi.cloud.blockscout.com

