### PR TITLE
docs: change hoodi.cloud.blockscout.com to eth-hoodi.blockscout.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Meet `--hoodi`, the second long-standing, merged-from-genesis, public Ethereum t
 * Homepage: [hoodi.ethpandaops.io](https://hoodi.ethpandaops.io)
 * Staking Launchpad: [hoodi.launchpad.ethereum.org](https://hoodi.launchpad.ethereum.org)
 * Block Explorers
-  * [hoodi.cloud.blockscout.com](https://hoodi.cloud.blockscout.com/)
+  * [eth-hoodi.blockscout.com](https://eth-hoodi.blockscout.com/)
   * [hoodi.etherscan.io](https://hoodi.etherscan.io/)
   * [hoodi.beaconcha.in](https://hoodi.beaconcha.in/)
   * [light-hoodi.beaconcha.in](https://light-hoodi.beaconcha.in/)


### PR DESCRIPTION
The old hoodi.cloud.blockscout.com was migrated eth-hoodi.blockscout.com

<img width="721" alt="image" src="https://github.com/user-attachments/assets/90d7ec00-0906-405e-8e77-36b9aad9a8b5" />
